### PR TITLE
feat: Activate meta-descriptions plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ plugins:
       password_button_text: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" height="1em" width="1em"><!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M416 32h-64c-17.67 0-32 14.33-32 32s14.33 32 32 32h64c17.67 0 32 14.33 32 32v256c0 17.67-14.33 32-32 32h-64c-17.67 0-32 14.33-32 32s14.33 32 32 32h64c53.02 0 96-42.98 96-96V128C512 74.98 469 32 416 32zM342.6 233.4l-128-128c-12.51-12.51-32.76-12.49-45.25 0c-12.5 12.5-12.5 32.75 0 45.25L242.8 224H32C14.31 224 0 238.3 0 256s14.31 32 32 32h210.8l-73.38 73.38c-12.5 12.5-12.5 32.75 0 45.25s32.75 12.5 45.25 0l128-128C355.1 266.1 355.1 245.9 342.6 233.4z"/></svg>'
   - custom-attributes:
       file: 'assets/css/custom_attributes.css'
+  - meta-descriptions
 extra_javascript:
   - assets/js/mathjax.js
   - assets/js/utils.js


### PR DESCRIPTION
Hi @Mara-Li! :wave: I noticed you're including the [mkdocs-meta-descriptions-plugin](https://github.com/prcr/mkdocs-meta-descriptions-plugin) in your `requirements.txt` file, but the plugin isn't active in your `mkdocs.yml` file. Could this be unintentional?

Feel free to close this pull request if you didn't intend to activate the plugin, of course. :+1: 